### PR TITLE
Add virtualenv prompt for robbyrussell theme

### DIFF
--- a/themes/robbyrussell/robbyrussell.theme.bash
+++ b/themes/robbyrussell/robbyrussell.theme.bash
@@ -18,8 +18,19 @@ function git_prompt_info() {
   echo -e "$SCM_PREFIX${bold_red}$SCM_BRANCH$SCM_STATE$SCM_SUFFIX"
 }
 
+function venv_prompt() {
+	python_venv=""
+	# Detect python venv
+	if [[ -n "${CONDA_DEFAULT_ENV}" ]]; then
+		python_venv="($PYTHON_VENV_CHAR${CONDA_DEFAULT_ENV}) "
+	elif [[ -n "${VIRTUAL_ENV}" ]]; then
+		python_venv="($PYTHON_VENV_CHAR$(basename "${VIRTUAL_ENV}")) "
+	fi
+	[[ -n "${python_venv}" ]] && echo "${python_venv}"
+}
+
 function prompt_command() {
-  PS1="${bold_green}➜  ${bold_cyan}\W${reset_color}$(scm_prompt_info)${normal} "
+  PS1="$(venv_prompt)${bold_green}➜  ${bold_cyan}\W${reset_color}$(scm_prompt_info)${normal} "
 }
 
 PROMPT_COMMAND=prompt_command


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Added virtualenv prompt for robbyrussell theme (same as in the [purity theme](https://github.com/Bash-it/bash-it/pull/1849))

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Usually when one `cd` into directory with active virtualenv name of the virtualenv is displayed on the left hand side in parentheses.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

cd into and out of the directory with virtualenv has desired effect

## Screenshots (if appropriate):

https://imgur.com/D0ZG5Nc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
